### PR TITLE
Fix: unknow-command bootstrap-iterm-workspace

### DIFF
--- a/start-iterm-workspace
+++ b/start-iterm-workspace
@@ -3,7 +3,7 @@
 config="$PWD/${1:-".iterm-workspace"}"
 
 if [ -f $config ]; then
-  bootstrap-iterm-workspace $config
+  ./bootstrap-iterm-workspace $config
 else
   echo "No config found at $config..."
   echo 'Creating empty config...'


### PR DESCRIPTION
*Environment*
 macOS Big Sur / Version 11.4

*Cause*
Running `sh or ./start-iterm-workspace` throws

```
bootstrap-iterm-workspace: command not found
```

if we get permission on executing `bootstrap-iterm-workspace` file
do give valid permissions to the file 
```
sudo chmod 755 <filename>
```